### PR TITLE
typo3/cms instread of typo3/cms-core as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": "8.7.*"
+    "typo3/cms": "8.7.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
composer require does not work if typo3/cms-core